### PR TITLE
Update config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
           name: install dependencies
           command: |
             wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
-            chmod +x miniconda.sh && ./miniconda.sh -b -p ~/miniconda
+            chmod +x miniconda.sh && bash ./miniconda.sh -b -p ~/miniconda
             export PATH="~/miniconda/bin:$PATH"
             conda update --yes --quiet conda
             conda create -n testenv --yes --quiet python=3


### PR DESCRIPTION
as a workaround to upstream bug, explicitely execut miniconda.sh in bash instead of relying on erroneous hashbang #!/bin/sh